### PR TITLE
`cleanup`

### DIFF
--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -25,6 +25,8 @@ set(sources ${sources}
 	src/handle/data/page/position_draw_setting.h
 	src/handle/data/page/position_setting.h
 	src/handle/data/page/slot_setting.h
+	src/handle/extra_data_holder.cpp
+	src/handle/extra_data_holder.h
 	src/handle/key_position_handle.cpp
 	src/handle/key_position_handle.h
 	src/handle/name_handle.cpp

--- a/src/equip/item.cpp
+++ b/src/equip/item.cpp
@@ -1,5 +1,6 @@
 ﻿#include "item.h"
 #include "equip_slot.h"
+#include "handle/extra_data_holder.h"
 #include "setting/mcm_setting.h"
 #include "util/constant.h"
 #include "util/helper.h"
@@ -74,10 +75,26 @@ namespace equip {
             return;
         }
 
-        if (!extra_vector.empty()) {
-            //extra = extra_vector.front();
-            extra = extra_vector.back();
-            /*if (left) {
+        auto* extra_handler = handle::extra_data_holder::get_singleton();
+        if (extra_handler->is_form_set(a_form)) {
+            auto extra_list = extra_handler->get_extra_list_for_form(a_form);
+            if (!extra_list.empty()) {
+                extra = extra_list.back();
+                extra_list.pop_back();
+                extra_handler->overwrite_extra_data_for_form(a_form, extra_list);
+            }
+        } else {
+            if (!extra_vector.empty()) {
+                extra = extra_vector.back();
+                extra_vector.pop_back();  //remove last item, because we already use that
+                extra_handler->init_extra_data(a_form, extra_vector);
+                logger::trace("set {} extra data for form {}"sv, extra_vector.size(), a_form->GetName());
+            }
+        }
+
+        //if (!extra_vector.empty()) {
+        //extra = extra_vector.back();
+        /*if (left) {
                 REL::Relocation<std::uintptr_t> extra_worn_left_vtbl{ RE::VTABLE_ExtraWornLeft[0] };
                 auto* worn_left =
                     (RE::ExtraWornLeft*)RE::BSExtraData::Create(sizeof(RE::ExtraWornLeft), extra_worn_left_vtbl.get());
@@ -87,7 +104,7 @@ namespace equip {
                 auto* worn = (RE::ExtraWorn*)RE::BSExtraData::Create(sizeof(RE::ExtraWorn), extra_worn_vtbl.get());
                 extra->Add(worn);
             }*/
-        }
+        //}
 
         const auto obj_right = a_player->GetActorRuntimeData().currentProcess->GetEquippedRightHand();
         const auto obj_left = a_player->GetActorRuntimeData().currentProcess->GetEquippedLeftHand();

--- a/src/event/key_manager.cpp
+++ b/src/event/key_manager.cpp
@@ -1,5 +1,6 @@
 ﻿#include "key_manager.h"
 #include "handle/ammo_handle.h"
+#include "handle/extra_data_holder.h"
 #include "handle/page_handle.h"
 #include "processing/game_menu_setting.h"
 #include "processing/setting_execute.h"
@@ -50,6 +51,8 @@ namespace event {
         if (processing::game_menu_setting::is_need_menu_open(ui)) {
             return event_result::kContinue;
         }
+
+        handle::extra_data_holder::get_singleton()->reset_data();
 
         for (auto event = *a_event; event; event = event->next) {
             if (event->eventType != RE::INPUT_EVENT_TYPE::kButton) {

--- a/src/handle/extra_data_holder.cpp
+++ b/src/handle/extra_data_holder.cpp
@@ -1,0 +1,74 @@
+#include "extra_data_holder.h"
+#include "util/string_util.h"
+
+namespace handle {
+    extra_data_holder* extra_data_holder::get_singleton() {
+        static extra_data_holder singleton;
+        return std::addressof(singleton);
+    }
+
+    void extra_data_holder::init_extra_data(const RE::TESForm* a_form,
+        const std::vector<RE::ExtraDataList*>& a_extra_data_list) {
+        if (!this->data_) {
+            this->data_ = new extra_data_holder_data();
+        }
+
+        extra_data_holder_data* data = this->data_;
+
+        if (!a_form || a_extra_data_list.empty()) {
+            return;
+        }
+
+        data->form_extra_data_map[a_form] = a_extra_data_list;
+        logger::trace("set extra data list, form {}, count {}"sv, a_form->GetName(), data->form_extra_data_map.size());
+    }
+
+    void extra_data_holder::overwrite_extra_data_for_form(const RE::TESForm* a_form,
+        const std::vector<RE::ExtraDataList*>& a_extra_data_list) {
+        if (!this->data_) {
+            return;
+        }
+        extra_data_holder_data* data = this->data_;
+
+        if (data->form_extra_data_map.contains(a_form)) {
+            data->form_extra_data_map[a_form] = a_extra_data_list;
+        }
+    }
+
+    void extra_data_holder::reset_data() {
+        if (!this->data_) {
+            return;
+        }
+        extra_data_holder_data* data = this->data_;
+
+        if (data->form_extra_data_map.empty()) {
+            return;
+        }
+
+        logger::trace("before reset, extra data list {}"sv, data->form_extra_data_map.size());
+        data->form_extra_data_map.clear();
+        logger::trace("did reset, extra data list {}"sv, data->form_extra_data_map.size());
+    }
+
+    bool extra_data_holder::is_form_set(const RE::TESForm* a_form) {
+        if (!this->data_) {
+            return false;
+        }
+        extra_data_holder_data* data = this->data_;
+
+        return data->form_extra_data_map.contains(a_form);
+    }
+
+    std::vector<RE::ExtraDataList*> extra_data_holder::get_extra_list_for_form(const RE::TESForm* a_form) {
+        if (!this->data_) {
+            return {};
+        }
+        extra_data_holder_data* data = this->data_;
+
+        if (data->form_extra_data_map.contains(a_form)) {
+            return data->form_extra_data_map.at(a_form);
+        }
+
+        return {};
+    }
+}  // handle

--- a/src/handle/extra_data_holder.h
+++ b/src/handle/extra_data_holder.h
@@ -1,0 +1,30 @@
+#pragma once
+
+namespace handle {
+    class extra_data_holder {
+    public:
+        static extra_data_holder* get_singleton();
+        void init_extra_data(const RE::TESForm* a_form, const std::vector<RE::ExtraDataList*>& a_extra_data_list);
+        void overwrite_extra_data_for_form(const RE::TESForm* a_form,
+            const std::vector<RE::ExtraDataList*>& a_extra_data_list);
+        void reset_data();
+        bool is_form_set(const RE::TESForm* a_form);
+        [[nodiscard]] std::vector<RE::ExtraDataList*> get_extra_list_for_form(const RE::TESForm* a_form);
+
+        extra_data_holder(const extra_data_holder&) = delete;
+        extra_data_holder(extra_data_holder&&) = delete;
+
+        extra_data_holder& operator=(const extra_data_holder&) const = delete;
+        extra_data_holder& operator=(extra_data_holder&&) const = delete;
+
+    private:
+        extra_data_holder() : data_(nullptr) {}
+        ~extra_data_holder() = default;
+
+        struct extra_data_holder_data {
+            std::map<const RE::TESForm*, std::vector<RE::ExtraDataList*>> form_extra_data_map;
+        };
+
+        extra_data_holder_data* data_;
+    };
+}  // handle

--- a/src/handle/key_position_handle.h
+++ b/src/handle/key_position_handle.h
@@ -21,7 +21,6 @@ namespace handle {
 
     private:
         key_position_handle() : data_(nullptr) {}
-
         ~key_position_handle() = default;
 
         struct key_position_handle_data {

--- a/src/handle/name_handle.h
+++ b/src/handle/name_handle.h
@@ -18,7 +18,6 @@ namespace handle {
 
     private:
         name_handle() : data_(nullptr) {}
-
         ~name_handle() = default;
 
         struct name_handle_data {

--- a/src/handle/page_handle.h
+++ b/src/handle/page_handle.h
@@ -40,7 +40,6 @@ namespace handle {
 
     private:
         page_handle() : data_(nullptr) {}
-
         ~page_handle() = default;
 
         static void get_offset_values(position_type a_position,

--- a/src/hook/player_hook.cpp
+++ b/src/hook/player_hook.cpp
@@ -35,9 +35,11 @@ namespace hook {
         pick_up_object_(a_this, a_object, a_count, a_arg3, a_play_sound);
 
         if (a_object->GetPlayable()) {
-            if (const auto obj = a_object->GetBaseObject(); obj->IsInventoryObject()) {
-                processing::set_setting_data::set_new_item_count_if_needed(obj, static_cast<int32_t>(a_count));
-            }
+            //if (const auto obj = a_object->GetBaseObject(); obj->IsInventoryObject()) {
+            //processing::set_setting_data::set_new_item_count_if_needed(obj, static_cast<int32_t>(a_count));
+            //}
+            processing::set_setting_data::set_new_item_count_if_needed(a_object->GetBaseObject(),
+                static_cast<int32_t>(a_count));
         }
     }
 


### PR DESCRIPTION
* fixed: the first the all the extra list for a form will be added to a list, if the Item is used a second time during one button press we take the next item, because at that time the extra data worn or worn left is not set yet. The list is reset before every new key input, if there is data set.
* adjusted: count update when picking up item