### PR TITLE
`fix` #37

### DIFF
--- a/src/equip/magic.cpp
+++ b/src/equip/magic.cpp
@@ -33,8 +33,13 @@ namespace equip {
         logger::trace("spell {} is type {}"sv, spell->GetName(), static_cast<uint32_t>(casting_type));
         if (a_action == action_type::instant && casting_type != RE::MagicSystem::CastingType::kConcentration) {
             if (config::mcm_setting::get_elden_demon_souls()) {
-                //normally in elden just top uses instant for spells
-                equip::equip_slot::un_equip_shout_slot(a_player);
+                auto selected_power = a_player->GetActorRuntimeData().selectedPower;
+                if (selected_power) {
+                    logger::trace(
+                        "power/shout {} is equipped, will only cast spell in elden mode if shout slot is empty. return."sv,
+                        selected_power->GetName());
+                    return;
+                }
             }
             const auto actor = a_player->As<RE::Actor>();
             auto caster = actor->GetMagicCaster(get_casting_source(a_slot));
@@ -188,10 +193,9 @@ namespace equip {
         }
 
         if (a_action == handle::slot_setting::action_type::instant) {
-            //try that
             if (config::mcm_setting::get_elden_demon_souls()) {
-                //normally in elden just top uses instant for spells
-                equip::equip_slot::un_equip_shout_slot(a_player);
+                logger::warn("form {}, will only not instant cast power in elden mode. return."sv, spell->GetName());
+                return;
             }
             //might not consider daily cool downs
             const auto actor = a_player->As<RE::Actor>();


### PR DESCRIPTION
* fixed: allow manual equipped power/shout to be cast if an spell is selected in elden mode in the top slot (shout slot needs to be empty)
* adjusted: powers are not allowed be instant cast in elden mode in the top slot (because the same handling for the user is with or without equipping)